### PR TITLE
Fix: Use fixed PNG palette

### DIFF
--- a/wavey/__main__.py
+++ b/wavey/__main__.py
@@ -60,7 +60,7 @@ def savefig(path: Path) -> None:
     plt.savefig(bts, format="png")
 
     with PIL.Image.open(bts) as img:
-        img2 = img.convert("RGB").convert("P", palette=PIL.Image.Palette.ADAPTIVE)
+        img2 = img.convert("RGB").convert("P", palette=PIL.Image.Palette.WEB)
         img2.save(path, format="png")
 
 


### PR DESCRIPTION
Small fix to #13. Switch to a fixed palette so that the colorbar's appearance is the same across frames. The PNG file sizes are slightly larger, but this is still an overall improvement.